### PR TITLE
[test]  배송 단위 테스트

### DIFF
--- a/backend/src/test/java/com/synerge/order101/shipment/event/ShipmentInTransitListenerTest.java
+++ b/backend/src/test/java/com/synerge/order101/shipment/event/ShipmentInTransitListenerTest.java
@@ -1,0 +1,68 @@
+package com.synerge.order101.shipment.event;
+
+import com.synerge.order101.common.enums.ShipmentStatus;
+import com.synerge.order101.order.model.repository.StoreOrderDetailRepository;
+import com.synerge.order101.order.model.repository.StoreOrderRepository;
+import com.synerge.order101.product.model.entity.Product;
+import com.synerge.order101.shipment.model.entity.Shipment;
+import com.synerge.order101.shipment.model.repository.ShipmentRepository;
+import com.synerge.order101.store.model.entity.Store;
+import com.synerge.order101.store.model.entity.StoreInventory;
+import com.synerge.order101.store.model.repository.StoreInventoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentInTransitListenerTest {
+
+    @InjectMocks ShipmentInTransitListener listener;
+    @Mock ShipmentRepository shipmentRepository;
+    @Mock StoreOrderRepository storeOrderRepository;
+    @Mock StoreOrderDetailRepository storeOrderDetailRepository;
+    @Mock StoreInventoryRepository storeInventoryRepository;
+
+    @Test
+    void ApplyInTransit() {
+        // shipment
+        Shipment shipment = mock(Shipment.class);
+        given(shipment.getShipmentId()).willReturn(10L);
+        given(shipment.getShipmentStatus()).willReturn(ShipmentStatus.IN_TRANSIT);
+        given(shipment.getInTransitApplied()).willReturn(false);
+        given(shipmentRepository.findById(10L)).willReturn(Optional.of(shipment));
+
+        // order & store
+        var store = mock(Store.class);
+        var order = mock(com.synerge.order101.order.model.entity.StoreOrder.class);
+        given(order.getStoreOrderId()).willReturn(11L);
+        given(order.getStore()).willReturn(store);
+        given(storeOrderRepository.findById(11L)).willReturn(Optional.of(order));
+
+        // line & product
+        var product = mock(Product.class);
+        var line = mock(com.synerge.order101.order.model.entity.StoreOrderDetail.class);
+        given(line.getProduct()).willReturn(product);
+        given(line.getOrderQty()).willReturn(new BigDecimal("5"));
+        given(storeOrderDetailRepository.findByStoreOrder_StoreOrderId(11L)).willReturn(List.of(line));
+
+        // inventory
+        StoreInventory inv = StoreInventory.create(store, product);
+        given(storeInventoryRepository.findByStoreAndProduct(store, product)).willReturn(Optional.of(inv));
+
+        // when
+        listener.applyInTransit(new ShipmentInTransitEvent(10L, 11L, 111L));
+
+        // then
+        verify(storeInventoryRepository).save(any(StoreInventory.class));
+        verify(shipmentRepository).save(shipment);
+    }
+}

--- a/backend/src/test/java/com/synerge/order101/shipment/event/ShipmentInventoryListenerTest.java
+++ b/backend/src/test/java/com/synerge/order101/shipment/event/ShipmentInventoryListenerTest.java
@@ -1,0 +1,161 @@
+package com.synerge.order101.shipment.event;
+
+import com.synerge.order101.common.enums.ShipmentStatus;
+import com.synerge.order101.common.exception.CustomException;
+import com.synerge.order101.order.model.entity.StoreOrder;
+import com.synerge.order101.order.model.entity.StoreOrderDetail;
+import com.synerge.order101.order.model.repository.StoreOrderDetailRepository;
+import com.synerge.order101.order.model.repository.StoreOrderRepository;
+import com.synerge.order101.product.model.entity.Product;
+import com.synerge.order101.shipment.exception.errorcode.ShipmentErrorCode;
+import com.synerge.order101.shipment.model.entity.Shipment;
+import com.synerge.order101.shipment.model.repository.ShipmentRepository;
+import com.synerge.order101.store.model.entity.Store;
+import com.synerge.order101.store.model.entity.StoreInventory;
+import com.synerge.order101.store.model.repository.StoreInventoryRepository;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ShipmentInventoryListenerTest {
+
+    @InjectMocks
+    private ShipmentInventoryListener listener;
+
+    @Mock private ShipmentRepository shipmentRepository;
+    @Mock private StoreOrderRepository storeOrderRepository;
+    @Mock private StoreOrderDetailRepository storeOrderDetailRepository;
+    @Mock private StoreInventoryRepository storeInventoryRepository;
+
+    @Test
+    @Order(1)
+    //delivered_정상_적재__inTransit_이미_반영됨
+    void AlreadyApplyDeliveredInTransit() {
+        // given
+        // shipment: DELIVERED / inventoryApplied=false / inTransitApplied=true
+        Shipment shipment = mock(Shipment.class);
+
+        given(shipment.getShipmentStatus()).willReturn(ShipmentStatus.DELIVERED);
+        given(shipment.getInventoryApplied()).willReturn(false);
+        given(shipment.getInTransitApplied()).willReturn(true);
+        given(shipmentRepository.findById(10L)).willReturn(Optional.of(shipment));
+
+        // 주문/가맹점
+        Store store = mock(Store.class);
+        StoreOrder order = mock(StoreOrder.class);
+        given(order.getStoreOrderId()).willReturn(11L);
+        given(order.getStore()).willReturn(store);
+        given(storeOrderRepository.findById(11L)).willReturn(Optional.of(order));
+
+        // 주문 상세 1줄 (qty=5, 특정 상품)
+        Product product = mock(Product.class);
+        StoreOrderDetail line = mock(StoreOrderDetail.class);
+        given(line.getProduct()).willReturn(product);
+        given(line.getOrderQty()).willReturn(new BigDecimal("5"));
+        given(storeOrderDetailRepository.findByStoreOrder_StoreOrderId(11L)).willReturn(List.of(line));
+
+        // 기존 재고: 입고예정 5, 현재고 0
+        StoreInventory inv = StoreInventory.create(store, product);
+        inv.increaseInTransit(5);
+        given(storeInventoryRepository.findByStoreAndProduct(store, product)).willReturn(Optional.of(inv));
+
+        // when
+        listener.applyInventory(new ShipmentDeliveredEvent(10L, 11L, 111L));
+
+        // then (입고예정 －＞ 현재고 이동)
+        assertThat(inv.getInTransitQty()).isZero();
+        assertThat(inv.getOnHandQty()).isEqualTo(5);
+        verify(storeInventoryRepository, times(1)).save(inv);
+        verify(shipmentRepository, times(1)).save(shipment);
+    }
+
+    @Test
+    @Order(2)
+    //delivered 정상_적재 InTransit 미반영 바로 현재고만증가
+    void DeliveredInTransitAddOn_hand_qty() {
+        // given
+        Shipment shipment = mock(Shipment.class);
+        given(shipment.getShipmentStatus()).willReturn(ShipmentStatus.DELIVERED);
+        given(shipment.getInventoryApplied()).willReturn(false);
+        given(shipment.getInTransitApplied()).willReturn(false); // 중간단계는 미적용
+        given(shipmentRepository.findById(20L)).willReturn(Optional.of(shipment));
+
+        Store store = mock(Store.class);
+        StoreOrder order = mock(StoreOrder.class);
+        given(order.getStoreOrderId()).willReturn(21L);
+        given(order.getStore()).willReturn(store);
+        given(storeOrderRepository.findById(21L)).willReturn(Optional.of(order));
+
+        Product product = mock(Product.class);
+        StoreOrderDetail line = mock(StoreOrderDetail.class);
+        given(line.getProduct()).willReturn(product);
+        given(line.getOrderQty()).willReturn(new BigDecimal("3"));
+        given(storeOrderDetailRepository.findByStoreOrder_StoreOrderId(21L)).willReturn(List.of(line));
+
+        // 기존 재고: 입고예정 0, 현재고 0
+        StoreInventory inv = StoreInventory.create(store, product);
+        given(storeInventoryRepository.findByStoreAndProduct(store, product)).willReturn(Optional.of(inv));
+
+        // when
+        listener.applyInventory(new ShipmentDeliveredEvent(20L, 21L, 111L));
+
+        // then (입고예정은 그대로, 현재고만 +3)
+        assertThat(inv.getInTransitQty()).isZero();
+        assertThat(inv.getOnHandQty()).isEqualTo(3);
+        verify(storeInventoryRepository).save(inv);
+        verify(shipmentRepository).save(shipment);
+    }
+
+    @Test
+    @Order(3)
+    //delivered 이미 적재됨 - 멱등
+    void DeliveredAlreadyApplyIdempotence () {
+        // given
+        Shipment shipment = mock(Shipment.class);
+        given(shipment.getInventoryApplied()).willReturn(true);  // 이미 반영됨
+        given(shipmentRepository.findById(30L)).willReturn(Optional.of(shipment));
+
+        // when
+        listener.applyInventory(new ShipmentDeliveredEvent(30L, 31L, 111L));
+
+        // then (어떤 저장 동작도 없어야 함)
+        verifyNoInteractions(storeOrderRepository, storeOrderDetailRepository, storeInventoryRepository);
+        verify(shipmentRepository, never()).save(any());
+    }
+
+    @Test
+    @Order(4)
+    //delivered 아님  - 예외
+    void NotDeliveredException() {
+        // given
+        Shipment shipment = mock(Shipment.class);
+
+        given(shipment.getInventoryApplied()).willReturn(false);
+        given(shipment.getShipmentStatus()).willReturn(ShipmentStatus.IN_TRANSIT); // DELIVERED 아님
+        given(shipmentRepository.findById(40L)).willReturn(Optional.of(shipment));
+
+        // when & then
+        assertThatThrownBy(() ->
+                listener.applyInventory(new ShipmentDeliveredEvent(40L, 41L, 111L))
+        )
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ShipmentErrorCode.SHIPMENT_NOT_DELIVERED.getMessage());
+
+        verifyNoInteractions(storeOrderRepository, storeOrderDetailRepository, storeInventoryRepository);
+        verify(shipmentRepository, never()).save(any());
+    }
+}

--- a/backend/src/test/java/com/synerge/order101/shipment/model/service/ShipmentListServiceTest.java
+++ b/backend/src/test/java/com/synerge/order101/shipment/model/service/ShipmentListServiceTest.java
@@ -38,7 +38,7 @@ class ShipmentListServiceTest {
     private ShipmentListRepository shipmentListRepository;
 
     @Test @Order(1)
-    void GET_SHIPMENT_LIST_SUCCESS() {
+    void GetShipmentListSuccess() {
         // given
         var dto = new ShipmentResponseDto(1L, "ORDER-1", "가맹점A", null, ShipmentStatus.WAITING, LocalDateTime.now());
         var page = new PageImpl<>(List.of(dto), PageRequest.of(0,20), 1);
@@ -55,7 +55,7 @@ class ShipmentListServiceTest {
 
     @Test
     @Order(2)
-    void GET_SHIPMENT_LIST_NONE_EXCEPTION() {
+    void GetShipmentListNoneException() {
         // given
         given(shipmentListRepository.findPage(any(), any(), any(), any(), any(), any()))
                 .willReturn(Page.empty());


### PR DESCRIPTION
<!-- 
제목 양식
[타입] 간단한 설명 (#이슈번호)
ex) [Feat] 게시글 생성 API 구현 (#23)

Feat	새로운 기능 추가
Fix	버그 수정
Refactor	코드 리팩토링
Style	스타일, 포맷 수정 (기능 변화 없음)
Chore	빌드, 설정, 패키지 등 기타 작업
Docs	문서 추가 또는 수정
Test	테스트 코드 추가/보완
-->

## 🔖 작업 개요
<!-- 이번 PR에서 어떤 기능/버그를 다뤘는지 간단 요약 -->
- 배송 이벤트 리스너 및 배송 목록 조회 서비스 단위 테스트
- JUnit5 + Mockito 사용  

</br>

## 📝 작업 목적
<!-- 작업의 목적을 간략하게 작성 -->
- 배송 상태 변화에 따른 재고 반영 로직 검증
- 멱등성 및 예외 처리 검증
- 배송 리스트 조회 서비스의 정상/예외를 검증 

</br>

## 🎯 작업 내용
<!-- 어떤 변경 사항이 있었는지 구체적으로 설명 -->
1. ShipmentInventoryListenerTest(배송 목록 조회)
- GetShipmentListSuccess - 정상 조회 시 데이터 반환 검증
- GetShipmentListNoneException - 데이터 미존재시 예외 처리 검증
2. ShipmentInventoryListenerTest(배송 완료 이벤트)
- AlreadyApplyDeliveredInTransit - 입고 예정 재고에서 현재고 전환 검증
- DeliveredInTransitAddOn_hand_qty - IN_TRANSIT 미반영 시 현재고만 증가
- DeliveredAlreadyApplyIdempotence - 이미 처리된 배송의 멱등성 보장
- NotDeliveredException - 잘못된 상태에서의 예외처리
3. ShipmentInTransitListenerTest(배송중 이벤트)
- ApplyInTransit - 배송 중 이벤트에 따른 입고 예정 수량 증가 검증 



</br>


## 🧪 관련 이슈
<!-- 연결된 이슈가 있다면 아래에 작성 -->
- #37 

</br>


## ✅ 참고 자료
<!-- 참고한 외부 문서, 링크가 있다면 작성 -->
- 
